### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI/CD
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["master"]


### PR DESCRIPTION
Potential fix for [https://github.com/pde-bakk/personal-site/security/code-scanning/3](https://github.com/pde-bakk/personal-site/security/code-scanning/3)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions in the workflow to the least privilege required. This workflow only needs to read repository contents to check out the code and install dependencies, so a minimal `permissions: contents: read` block is sufficient. Adding this at the workflow root (top level) ensures all jobs inherit these restricted permissions unless they define their own.

Concretely, edit `.github/workflows/ci.yml` and insert a `permissions:` block near the top, at the same indentation level as `name:` and `on:`. For example, after the `name: Node.js CI/CD` line, add:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed; this is purely a YAML configuration change for GitHub Actions. Existing job steps (checkout, setup-node, npm commands) will continue to work as they only require read access to repo contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
